### PR TITLE
Fix linke in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Progressive Rendering
 
 This is a port of Dinesh Pandiyan's [progressive rendering demo](https://github.com/flexdinesh/progressive-rendering) to Elixir.
-As described in their article here: [https://medium.com/the-thinkmill/progressive-rendering-the-key-to-faster-web-ebfbbece41a4]()
+As described in their article here: https://medium.com/the-thinkmill/progressive-rendering-the-key-to-faster-web-ebfbbece41a4
 
 > Progressive rendering is a technique where you can stream portions of a webpage as chunks from the server and the browser will render it as soon as the chunks are received without waiting for the whole HTML string to be received.
 


### PR DESCRIPTION
The empty link body was being picked up by GitHub in an unexpected way, attempting to link to:

https://github.com/rowlandcodes/progressive-rendering/blob/main

which would 404.

GitHub seems happy enough to generate an anchor tag with the bare link, which is what the change leaves it as.

----

If you'd prefer, I could propose the change to make "here" be the link, but I'm assuming you'd prefer.